### PR TITLE
Add package discovery support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,15 @@
             "Softon\\Indipay\\": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Softon\\Indipay\\IndipayServiceProvider"
+            ],
+            "aliases": {
+                "Indipay": "Softon\\Indipay\Facades\Indipay"
+            }
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
                 "Softon\\Indipay\\IndipayServiceProvider"
             ],
             "aliases": {
-                "Indipay": "Softon\\Indipay\Facades\Indipay"
+                "Indipay": "Softon\\Indipay\\Facades\\Indipay"
             }
         }
     }


### PR DESCRIPTION
Support auto-discovery of service provider and facade during package installation, as per https://laravel.com/docs/5.5/packages