### PR TITLE
mcrypt not supported from 7.1 and above

### DIFF
--- a/src/Gateways/CCAvenueGateway.php
+++ b/src/Gateways/CCAvenueGateway.php
@@ -102,50 +102,38 @@ class CCAvenueGateway implements PaymentGatewayInterface {
         }
 
     }
-
-    /**
-     * CCAvenue Encrypt Function
-     *
-     * @param $plainText
-     * @param $key
+    
+     /**
+     * CCAvenue encryption
+     * @param $plainText string
+     * @param $key string
      * @return string
      */
-    protected function encrypt($plainText,$key)
+    public function encrypt($plainText, $key)
     {
-        $secretKey = $this->hextobin(md5($key));
+        $key = $this->hextobin(md5($key));
         $initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-        $openMode = @mcrypt_module_open(MCRYPT_RIJNDAEL_128, '','cbc', '');
-        $blockSize = @mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, 'cbc');
-        $plainPad = $this->pkcs5_pad($plainText, $blockSize);
-        if (@mcrypt_generic_init($openMode, $secretKey, $initVector) != -1)
-        {
-            $encryptedText = @mcrypt_generic($openMode, $plainPad);
-            @mcrypt_generic_deinit($openMode);
-
-        }
-        return bin2hex($encryptedText);
+        $openMode = openssl_encrypt($plainText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
+        $encryptedText = bin2hex($openMode);
+        return $encryptedText;
     }
+    
 
     /**
-     * CCAvenue Decrypt Function
-     *
-     * @param $encryptedText
+     * CCAvenue decryption
+     * @param $encryptedText string
      * @param $key
      * @return string
      */
-    protected function decrypt($encryptedText,$key)
+    public function decrypt($encryptedText, $key)
     {
-        $secretKey = $this->hextobin(md5($key));
+        $key = $this->hextobin(md5($key));
         $initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-        $encryptedText=$this->hextobin($encryptedText);
-        $openMode = @mcrypt_module_open(MCRYPT_RIJNDAEL_128, '','cbc', '');
-        @mcrypt_generic_init($openMode, $secretKey, $initVector);
-        $decryptedText = @mdecrypt_generic($openMode, $encryptedText);
-        $decryptedText = rtrim($decryptedText, "\0");
-        @mcrypt_generic_deinit($openMode);
+        $encryptedText = $this->hextobin($encryptedText);
+        $decryptedText = openssl_decrypt($encryptedText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
         return $decryptedText;
-
     }
+  
 
 
     /**


### PR DESCRIPTION
From PHP7.1 mcrypt is deprecated and from PHP7.2  mcrypt has been removed.
To avoid error, OpenSSL encryption is used as per ccavenue